### PR TITLE
Fix more build problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.d
 *.o
 *.swp
 moc-adapter

--- a/Adapters/ZigBeeAdapter/ZigBeeAdapter.cpp
+++ b/Adapters/ZigBeeAdapter/ZigBeeAdapter.cpp
@@ -75,68 +75,68 @@ adapter::zigbee::Adapter::Shutdown()
 
 int32_t
 adapter::zigbee::Adapter::EnumDevices(
-    bridge::EnumDeviceOptions opts,
-    bridge::AdapterDeviceVector& deviceList,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    bridge::EnumDeviceOptions,
+    bridge::AdapterDeviceVector&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::GetProperty(
-    shared_ptr<bridge::IAdapterProperty>& prop,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    shared_ptr<bridge::IAdapterProperty>&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::SetProperty(
-    shared_ptr<bridge::IAdapterProperty> const& prop,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    shared_ptr<bridge::IAdapterProperty> const&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::GetPropertyValue(
-    shared_ptr<bridge::IAdapterProperty> const& prop,
-    std::string const& attributeName,
-    shared_ptr<bridge::IAdapterValue>& value,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    shared_ptr<bridge::IAdapterProperty> const&,
+    std::string const&,
+    shared_ptr<bridge::IAdapterValue>&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::SetPropertyValue(
-    shared_ptr<bridge::IAdapterProperty> const& prop,
-    shared_ptr<bridge::IAdapterValue> const& value,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    shared_ptr<bridge::IAdapterProperty> const&,
+    shared_ptr<bridge::IAdapterValue> const&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::CallMethod(
-    shared_ptr<bridge::IAdapterMethod>& method,
-    shared_ptr<bridge::IAdapterIoRequest>* req)
+    shared_ptr<bridge::IAdapterMethod>&,
+    shared_ptr<bridge::IAdapterIoRequest>*)
 {
   return -1;
 }
 
 int32_t
 adapter::zigbee::Adapter::RegisterSignalListener(
-  std::string const& signalName,
-  shared_ptr<bridge::IAdapterSignalListener> const& listener,
-  void* argp,
-  bridge::IAdapter::RegistrationHandle& handle)
+  std::string const&,
+  shared_ptr<bridge::IAdapterSignalListener> const&,
+  void*,
+  bridge::IAdapter::RegistrationHandle&)
 {
   return -1;
 }
 
 int32_t
-adapter::zigbee::Adapter::UnregisterSignalListener(bridge::IAdapter::RegistrationHandle const& h)
+adapter::zigbee::Adapter::UnregisterSignalListener(bridge::IAdapter::RegistrationHandle const&)
 {
   return -1;
 }

--- a/Bridge/AllJoynAbout.cpp
+++ b/Bridge/AllJoynAbout.cpp
@@ -99,7 +99,7 @@ AllJoynAbout::GetDeviceId(std::string& deviceId)
 }
 
 QStatus
-AllJoynAbout::ReadDeviceId(std::string& s)
+AllJoynAbout::ReadDeviceId(std::string&)
 {
   // TODO read from config
   return ER_FAIL;

--- a/Bridge/AllJoynHelper.cpp
+++ b/Bridge/AllJoynHelper.cpp
@@ -99,7 +99,10 @@ bridge::AllJoynHelper::SetMsgArg(IAdapterValue const& adapterValue, ajn::MsgArg&
     break;
 
     case common::Variant::DataType::BooleanArray:
-      st = SetMsgArg<bool>(m, sig.c_str(), val.ToBooleanArray());
+      /* Using vector<uint8_t> instead of vector<bool>, since vector<bool> is a
+       * bitfield and we can't access the underlying array easily.
+       * http://en.cppreference.com/w/cpp/container/vector_bool */
+      st = SetMsgArg<uint8_t>(m, sig.c_str(), val.ToUInt8Array());
     break;
 
     case common::Variant::DataType::UInt8Array:

--- a/Bridge/AllJoynHelper.cpp
+++ b/Bridge/AllJoynHelper.cpp
@@ -141,6 +141,33 @@ bridge::AllJoynHelper::SetMsgArg(IAdapterValue const& adapterValue, ajn::MsgArg&
 
   return st;
 }
+
+template<>
+QStatus bridge::AllJoynHelper::SetMsgArg(ajn::MsgArg& msg, std::string const& sig, std::vector<std::string> const& arr)
+{
+  QStatus st = ER_OK;
+
+  if (!arr.empty())
+  {
+    int n = static_cast<int>(arr.size());
+
+    typedef char const* value_type;
+    value_type* p = new value_type[n];
+
+    for (int i = 0; i < n; ++i)
+      p[i] = arr[i].c_str();
+
+    st = msg.Set(sig.c_str(), n, p);
+    msg.Stabilize();
+  }
+  else
+  {
+    st = msg.Set(sig.c_str(), 1, "");
+    msg.Stabilize();
+  }
+
+  return st;
+}
    
 QStatus
 bridge::AllJoynHelper::SetMsgArgFromAdapterObject(IAdapterValue const& adapterValue, ajn::MsgArg&, DeviceMain*)

--- a/Bridge/AllJoynHelper.cpp
+++ b/Bridge/AllJoynHelper.cpp
@@ -143,11 +143,12 @@ bridge::AllJoynHelper::SetMsgArg(IAdapterValue const& adapterValue, ajn::MsgArg&
 }
    
 QStatus
-bridge::AllJoynHelper::SetMsgArgFromAdapterObject(IAdapterValue const& adapterValue, ajn::MsgArg& msg, DeviceMain* deviceMain)
+bridge::AllJoynHelper::SetMsgArgFromAdapterObject(IAdapterValue const& adapterValue, ajn::MsgArg&, DeviceMain*)
 {
   // TODO:
   QStatus st = ER_OK;
   common::Variant const& val = adapterValue.GetData();
+  QCC_UNUSED(val);
   // std::string path = deviceMain->GetBusObjectPath(adapterValue);
 
   return st;
@@ -187,7 +188,7 @@ bridge::AllJoynHelper::GetAdapterValue(IAdapterValue& adapterValue, ajn::MsgArg 
 }
 
 QStatus
-bridge::AllJoynHelper::GetAdapterObject(IAdapterValue& adapterValue, ajn::MsgArg const& msg, DeviceMain *deviceMain)
+bridge::AllJoynHelper::GetAdapterObject(IAdapterValue&, ajn::MsgArg const&, DeviceMain*)
 {
   return ER_NOT_IMPLEMENTED;
 }

--- a/Bridge/AllJoynHelper.h
+++ b/Bridge/AllJoynHelper.h
@@ -46,9 +46,7 @@ namespace bridge
 
     if (!arr.empty())
     {
-      T const& ref = arr.front();
-      T const* p = &ref;
-      st = msg.Set(sig.c_str(), arr.size(), p);
+      st = msg.Set(sig.c_str(), arr.size(), arr.data());
       msg.Stabilize();
     }
     else

--- a/Bridge/AllJoynHelper.h
+++ b/Bridge/AllJoynHelper.h
@@ -63,31 +63,7 @@ namespace bridge
   }
 
   template<>
-  QStatus AllJoynHelper::SetMsgArg(ajn::MsgArg& msg, std::string const& sig, std::vector<std::string> const& arr)
-  {
-    QStatus st = ER_OK;
-
-    if (!arr.empty())
-    {
-      int n = static_cast<int>(arr.size());
-
-      typedef char const* value_type;
-      value_type* p = new value_type[n];
-
-      for (int i = 0; i < n; ++i)
-        p[i] = arr[i].c_str();
-        
-      st = msg.Set(sig.c_str(), n, p);
-      msg.Stabilize();
-    }
-    else
-    {
-      st = msg.Set(sig.c_str(), 1, "");
-      msg.Stabilize();
-    }
-
-    return st;
-  }
+  QStatus AllJoynHelper::SetMsgArg(ajn::MsgArg& msg, std::string const& sig, std::vector<std::string> const& arr);
  
 }
 

--- a/Bridge/ConfigManager.cpp
+++ b/Bridge/ConfigManager.cpp
@@ -10,8 +10,8 @@ namespace
 
   // TODO: make this configurable;
   std::string const kBridgeConfigFile = "BridgeConfig.xml";
-  int const kMaxConnectionAttempts = 60;
-  int const kReconnectDelay = 500;
+  //int const kMaxConnectionAttempts = 60;
+  //int const kReconnectDelay = 500;
   int const kDSBServicePort = 1000;
   uint32_t const kSessionLinkTimeout = 30; // seconds
 }
@@ -128,13 +128,13 @@ ConfigManager::BuildServiceName()
 }
 
 bool
-ConfigManager::AcceptSessionJoiner(ajn::SessionPort port, const char *joiner, const ajn::SessionOpts&)
+ConfigManager::AcceptSessionJoiner(ajn::SessionPort port, const char*, const ajn::SessionOpts&)
 {
   return port == m_sessionPort;
 }
 
 void
-ConfigManager::SessionJoined(ajn::SessionPort port, ajn::SessionId id, const char *joiner)
+ConfigManager::SessionJoined(ajn::SessionPort, ajn::SessionId id, const char*)
 {
   m_busAttachment->EnableConcurrentCallbacks();
   QStatus st = m_busAttachment->SetSessionListener(id, this);
@@ -154,7 +154,7 @@ ConfigManager::SessionJoined(ajn::SessionPort port, ajn::SessionId id, const cha
 }
 
 void
-ConfigManager::SessionMemberRemoved(ajn::SessionId, const char *uniqueName)
+ConfigManager::SessionMemberRemoved(ajn::SessionId, const char*)
 {
   // TODO: Reset auth access
   // TODO: End CSP file transfer

--- a/Bridge/DeviceMain.cpp
+++ b/Bridge/DeviceMain.cpp
@@ -18,7 +18,7 @@ bridge::DeviceMain::Shutdown()
 }
 
 QStatus
-bridge::DeviceMain::Initialize(shared_ptr<BridgeDevice> const& parent)
+bridge::DeviceMain::Initialize(shared_ptr<BridgeDevice> const&)
 {
   QStatus st = ER_OK;
   return st;
@@ -31,7 +31,7 @@ bridge::DeviceMain::IsMethodNameUnique(std::string const& name)
 }
 
 bool
-bridge::DeviceMain::IsSignalNameUnique(std::string const& name)
+bridge::DeviceMain::IsSignalNameUnique(std::string const&)
 {
   // TODO:
   return false;

--- a/Bridge/DeviceMain.h
+++ b/Bridge/DeviceMain.h
@@ -29,7 +29,7 @@ namespace bridge
     inline int GetIndexForMethod()
       { return m_indexForMethod++; }
 
-    inline std::string GetBusObjectPath(IAdapterProperty const& prop)
+    inline std::string GetBusObjectPath(IAdapterProperty const&)
       { return std::string(); }
 
   private:

--- a/Bridge/DeviceMethod.cpp
+++ b/Bridge/DeviceMethod.cpp
@@ -9,31 +9,25 @@ bridge::DeviceMethod::~DeviceMethod()
 }
 
 uint32_t
-bridge::DeviceMethod::InvokeMethod(
-  ajn::Message const&   msg,
-  ajn::MsgArg*          outargs,
-  size_t                numOutArgs)
+bridge::DeviceMethod::InvokeMethod(ajn::Message const&, ajn::MsgArg*, size_t)
 {
   return 0;
 }
 
 QStatus
-bridge::DeviceMethod::Initialize(shared_ptr<DeviceMain> const& parent, shared_ptr<IAdapterMethod> const& adapterMethod)
+bridge::DeviceMethod::Initialize(shared_ptr<DeviceMain> const&, shared_ptr<IAdapterMethod> const&)
 {
   return ER_NOT_IMPLEMENTED;
 }
 
 QStatus
-bridge::DeviceMethod::SetName(std::string const& name)
+bridge::DeviceMethod::SetName(std::string const&)
 {
   return ER_NOT_IMPLEMENTED;
 }
 
 QStatus
-bridge::DeviceMethod::BuildSignature(
-  AdapterValueVector const&     valueList,
-  std::string&                  signature,
-  std::string&                  parameterNames)
+bridge::DeviceMethod::BuildSignature(AdapterValueVector const&, std::string&, std::string&)
 {
   return ER_NOT_IMPLEMENTED;
 }

--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -55,12 +55,14 @@ namespace
 
   common::Logger::Level sDefaultLoggingLevel = common::Logger::DSB_LOGLEVEL_INFO;
 
-  #if defined(__APPLE__) || defined(__linux__)
+  #if defined(__APPLE__)
   #define ThreadId_FMT "%p"
   pthread_t GetCurrentThreadId() { return pthread_self(); }
+  #elif defined(__linux__)
+  #define ThreadId_FMT "%ld"
+  long GetCurrentThreadId() { return syscall(__NR_gettid); }
   #else
-  #define ThreadId_FMT "%d"
-  int32_t GetCurrentThreadId() { return syscall(__NR_gettid); }
+  #error ThreadId_FMT and GetCurrentThreadId() are not defined for your platform
   #endif
 }
 

--- a/Common/defines.h
+++ b/Common/defines.h
@@ -6,17 +6,16 @@ using std::shared_ptr;
 using std::weak_ptr;
 using std::enable_shared_from_this;
 using std::dynamic_pointer_cast;
-#include <assert.h>
-#define DSB_ASSERT(X) assert((X))
 #else
 #include <tr1/memory>
 using std::tr1::shared_ptr;
 using std::tr1::weak_ptr;
 using std::tr1::enable_shared_from_this;
 using std::tr1::dynamic_pointer_cast;
-#define DSB_ASSERT(X)
 #endif
 
+#include <assert.h>
+#define DSB_ASSERT(X) assert((X))
 
 class AllJoynBusObject;
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CXXFLAGS+=-Wno-ignored-qualifiers
 LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2 -pthread -luuid
 DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o, $(SRCS))
 OBJS=$(DEV_PROVIDER_OBJS)
+DEPS = $(OBJS:%.o=%.d)
 
 ifeq ($V, 1)
 CXX_PRETTY = $(CXX)
@@ -39,11 +40,12 @@ endif
 all: moc-adapter
 
 clean:
-	$(RM) moc-adapter *.o DeviceProviders/*.o Bridge/*.o Common/*.o Adapters/MockAdapter/*.o \
-    ZigBeeAdapter/*.o
+	$(RM) moc-adapter $(OBJS) $(DEPS)
 
 moc-adapter: $(OBJS)
 	$(LD_PRETTY) -o $@ $^ $(LDFLAGS)
 
 %.o: %.cpp
-	$(CXX_PRETTY) $(CXXFLAGS) -c -o $@ $<
+	$(CXX_PRETTY) $(CXXFLAGS) -MMD -c -o $@ $<
+
+-include $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,22 @@ LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2 -pthread -luuid
 DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o, $(SRCS))
 OBJS=$(DEV_PROVIDER_OBJS)
 
+ifeq ($V, 1)
+CXX_PRETTY = $(CXX)
+LD_PRETTY = $(CXX)
+else
+CXX_PRETTY = @echo " [CXX] $<" ; $(CXX)
+LD_PRETTY = @echo "[LINK] $@" ; $(CXX)
+endif
+
 all: moc-adapter
 
 clean:
 	$(RM) moc-adapter *.o DeviceProviders/*.o Bridge/*.o Common/*.o Adapters/MockAdapter/*.o \
     ZigBeeAdapter/*.o
 
-
-
 moc-adapter: $(OBJS)
-	$(CXX) -o $@ $^ $(LDFLAGS)
+	$(LD_PRETTY) -o $@ $^ $(LDFLAGS)
 
+%.o: %.cpp
+	$(CXX_PRETTY) $(CXXFLAGS) -c -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,16 @@ LIBXML_INC?=/usr/include/libxml2
 
 ALLJOYN_INSTALL_DIR?=/Users/jgladi200/Work/alljoyn/alljoyn-15.09.00a-src/build/darwin/x86/debug/dist/cpp
 
-CXXFLAGS=-D QCC_OS_GROUP_POSIX -Wall -Wextra -Wno-missing-field-initializers -Wno-deprecated-declarations -g -std=c++0x -I. -I$(ALLJOYN_INSTALL_DIR)/inc -I$(LIBXML_INC)
-CXXFLAGS+=-Wno-ignored-qualifiers
-LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2 -pthread -luuid
+CXXFLAGS=-D QCC_OS_GROUP_POSIX -Wall -Wextra -Wno-missing-field-initializers -Wno-deprecated-declarations -Wno-ignored-qualifiers -g -std=c++0x -I. -I$(ALLJOYN_INSTALL_DIR)/inc -I$(LIBXML_INC)
+LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2
 DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o, $(SRCS))
 OBJS=$(DEV_PROVIDER_OBJS)
 DEPS = $(OBJS:%.o=%.d)
+
+UNAME_S = $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    LDFLAGS += -pthread -luuid
+endif
 
 ifeq ($V, 1)
 CXX_PRETTY = $(CXX)


### PR DESCRIPTION
See commit titles. After this, building is less verbose (unless you pass V=1), .h files are picked up automatically, and there are no build warnings (on Fedora 23 and OS X).

The ThreadId_FMT one might be controversial, since it was just changed in commit 23b7c92c315b423be1082d6ea946f57e03729436, but pthread_t isn't necessarily a pointer on Linux.
