### PR TITLE
Expose AllJoyn devices

### DIFF
--- a/Adapters/MockAdapter/MockAdapter.cpp
+++ b/Adapters/MockAdapter/MockAdapter.cpp
@@ -1,12 +1,15 @@
-#include "Adapters/MockAdapter/MockAdapter.h"
-#include "Adapters/MockAdapter/MockDevices.h"
-#include "Adapters/MockAdapter/MockAdapterDevice.h"
+#include "MockAdapter.h"
+
+#include "MockDevices.h"
+#include "MockAdapterDevice.h"
+#include "Common/Log.h"
 
 #include <vector>
 #include <algorithm>
 
 namespace
 {
+  DSB_DECLARE_LOGNAME(MockAdapter);
   bridge::IAdapter::RegistrationHandle nextHandle = 0;
   bridge::IAdapter::RegistrationHandle GetNextRegistrationHandle()
   {
@@ -26,6 +29,7 @@ adapters::mock::MockAdapter::MockAdapter()
 
 adapters::mock::MockAdapter::~MockAdapter()
 {
+  Shutdown();
 }
 
 std::string
@@ -82,7 +86,18 @@ adapters::mock::MockAdapter::Initialize()
 int32_t
 adapters::mock::MockAdapter::Shutdown()
 {
-  return ER_NOT_IMPLEMENTED;
+  m_vendor.clear();
+  m_adapterName.clear();
+  m_version.clear();
+  m_exposedAdapterPrefix.clear();
+  m_exposedApplicationName.clear();
+  m_exposedApplicationGuid.clear();
+
+  m_devices.clear();
+  m_signals.clear();
+
+  m_signalListeners.clear();
+  return ER_OK;
 }
 
 

--- a/Bridge/AllJoynHelper.cpp
+++ b/Bridge/AllJoynHelper.cpp
@@ -369,16 +369,16 @@ bridge::AllJoynHelper::EncodeStringForRootServiceName(std::string const& s, std:
   t = TrimChar(t, '.');
 }
 
-void
-bridge::AllJoynHelper::EncodeStringForAppName(std::string const& s, std::string &t)
+std::string
+bridge::AllJoynHelper::EncodeStringForAppName(std::string const& s)
 {
-  t.clear();
-
+  std::string t;
   for (char ch : s)
   {
     if (std::isalnum(ch))
       t += ch;
   }
+  return t;
 }
 
 std::string

--- a/Bridge/AllJoynHelper.cpp
+++ b/Bridge/AllJoynHelper.cpp
@@ -322,12 +322,11 @@ bridge::AllJoynHelper::EncodeStringForInterfaceName(std::string const& s, std::s
   t = TrimChar(t, '.');
 }
 
-void
-bridge::AllJoynHelper::EncodeStringForServiceName(std::string const& s, std::string &t)
+std::string
+bridge::AllJoynHelper::EncodeStringForServiceName(std::string const& s)
 {
+  std::string t;
   std::string temp;
-
-  t.clear();
 
   for (char ch : s)
   {
@@ -341,14 +340,14 @@ bridge::AllJoynHelper::EncodeStringForServiceName(std::string const& s, std::str
       t += '_';
     t += temp;
   }
+  return t;
 }
 
-void
-bridge::AllJoynHelper::EncodeStringForRootServiceName(std::string const& s, std::string &t)
+std::string
+bridge::AllJoynHelper::EncodeStringForRootServiceName(std::string const& s)
 {
+  std::string t;
   char curr = '\0';
-
-  t.clear();
 
   for (char ch : s)
   {
@@ -367,6 +366,7 @@ bridge::AllJoynHelper::EncodeStringForRootServiceName(std::string const& s, std:
   }
 
   t = TrimChar(t, '.');
+  return t;
 }
 
 std::string

--- a/Bridge/AllJoynHelper.h
+++ b/Bridge/AllJoynHelper.h
@@ -35,7 +35,7 @@ namespace bridge
     static void EncodeStringForInterfaceName(std::string const& s, std::string& encoded);
     static void EncodeStringForServiceName(std::string const& s, std::string &encoded);
     static void EncodeStringForRootServiceName(std::string const& s, std::string &encoded);
-    static void EncodeStringForAppName(std::string const& s, std::string &encodeString);
+    static std::string EncodeStringForAppName(std::string const& s);
     static std::string TrimChar(std::string const& s, char c);
   };
 

--- a/Bridge/AllJoynHelper.h
+++ b/Bridge/AllJoynHelper.h
@@ -33,9 +33,9 @@ namespace bridge
     static void EncodeBusObjectName(std::string const& s, std::string &builtName);
     static void EncodePropertyOrMethodOrSignalName(std::string const& s, std::string &builtName);
     static void EncodeStringForInterfaceName(std::string const& s, std::string& encoded);
-    static void EncodeStringForServiceName(std::string const& s, std::string &encoded);
-    static void EncodeStringForRootServiceName(std::string const& s, std::string &encoded);
-    static std::string EncodeStringForAppName(std::string const& s);
+    static std::string EncodeStringForServiceName(std::string const&);
+    static std::string EncodeStringForRootServiceName(std::string const&);
+    static std::string EncodeStringForAppName(std::string const&);
     static std::string TrimChar(std::string const& s, char c);
   };
 

--- a/Bridge/Bridge.cpp
+++ b/Bridge/Bridge.cpp
@@ -305,9 +305,12 @@ bridge::DeviceSystemBridge::UpdateDevice(shared_ptr<IAdapterDevice> const& dev, 
 QStatus
 bridge::DeviceSystemBridge::CreateDevice(shared_ptr<IAdapterDevice> const& dev)
 {
-  shared_ptr<BridgeDevice> newDevice(new BridgeDevice());
+  if (!dev.get())
+    return ER_BAD_ARG_1;
+
+  shared_ptr<BridgeDevice> newDevice(new BridgeDevice(dev, m_adapter));
   
-  QStatus st = newDevice->Initialize(dev);
+  QStatus st = newDevice->Initialize();
   if (st == ER_OK)
     m_deviceList.insert(std::make_pair(GetKey(dev), newDevice));
 

--- a/Bridge/Bridge.cpp
+++ b/Bridge/Bridge.cpp
@@ -46,7 +46,7 @@ bridge::DeviceSystemBridge::Initialize()
     st = AllJoynInit();
     if (st != ER_OK)
     {
-      DSBLOG_WARN("Failed to initialize AllJoyn: 0x%x", st);
+      DSBLOG_WARN("Failed to initialize AllJoyn: %s", QCC_StatusText(st));
       goto Leave;
     }
     m_alljoynInitialized = true;
@@ -77,7 +77,7 @@ bridge::DeviceSystemBridge::InitializeInternal()
   st = InitializeAdapter();
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to intialize adapter: 0x%x", st);
+    DSBLOG_WARN("Failed to intialize adapter: %s", QCC_StatusText(st));
     goto Leave;
   }
 
@@ -90,14 +90,14 @@ bridge::DeviceSystemBridge::InitializeInternal()
   st = InitializeDevices();
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to initialize devices: 0x%x", st);
+    DSBLOG_WARN("Failed to initialize devices: %s", QCC_StatusText(st));
     goto Leave;
   }
 
   st = RegisterAdapterSignalHandlers(true);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to register adapter signal handlers: 0x%x", st);
+    DSBLOG_WARN("Failed to register adapter signal handlers: %s", QCC_StatusText(st));
     goto Leave;
   }
 
@@ -113,7 +113,7 @@ bridge::DeviceSystemBridge::Shutdown()
   st = ShutdownInternal();
   if (st != ER_OK)
   {
-    DSBLOG_WARN("failed to shutdown internal: 0x%x", st);
+    DSBLOG_WARN("failed to shutdown internal: %s", QCC_StatusText(st));
     return st;
   }
 
@@ -234,7 +234,7 @@ bridge::DeviceSystemBridge::RegisterAdapterSignalHandlers(bool isRegister)
         int ret = m_adapter->RegisterSignalListener((*itr)->GetName(), m_adapterSignalListener, NULL, handle);
         if (ret != 0)
         {
-          DSBLOG_WARN("failed to register signal listener on adapter: 0x%x", st);
+          DSBLOG_WARN("failed to register signal listener on adapter: %s", QCC_StatusText(st));
           if (st == ER_OK)
             ret = st;
         }
@@ -253,7 +253,7 @@ bridge::DeviceSystemBridge::RegisterAdapterSignalHandlers(bool isRegister)
       int ret = m_adapter->UnregisterSignalListener(*begin);
       if (ret != 0)
       {
-        DSBLOG_WARN("failed to unregister signal listener on adapter: 0x%x", st);
+        DSBLOG_WARN("failed to unregister signal listener on adapter: %s", QCC_StatusText(st));
         if (st == ER_OK)
           st = ER_FAIL;
       }
@@ -296,7 +296,7 @@ bridge::DeviceSystemBridge::UpdateDevice(shared_ptr<IAdapterDevice> const& dev, 
   {
     m_deviceList.erase(itr);
     if ((st = itr->second->Shutdown()) != ER_OK)
-      DSBLOG_WARN("failed to shutdown BridgeDevice: 0x%x", st);
+      DSBLOG_WARN("failed to shutdown BridgeDevice: %s", QCC_StatusText(st));
   }
 
   return st;

--- a/Bridge/BridgeDevice.cpp
+++ b/Bridge/BridgeDevice.cpp
@@ -1,4 +1,17 @@
-#include "Bridge/BridgeDevice.h"
+#include "BridgeDevice.h"
+
+#include "AllJoynHelper.h"
+
+bridge::BridgeDevice::BridgeDevice(const shared_ptr<IAdapterDevice>& dev, const shared_ptr<IAdapter>& adapter)
+  : m_parent(dev)
+  , m_busAttachment(AllJoynHelper::EncodeStringForAppName(adapter->GetExposedApplicationName()).c_str(), true)
+{
+}
+
+bridge::BridgeDevice::~BridgeDevice()
+{
+  Shutdown();
+}
 
 QStatus
 bridge::BridgeDevice::Shutdown()
@@ -8,7 +21,7 @@ bridge::BridgeDevice::Shutdown()
 }
 
 QStatus
-bridge::BridgeDevice::Initialize(shared_ptr<IAdapterDevice> const&)
+bridge::BridgeDevice::Initialize()
 {
   QStatus st = ER_OK;
   return st;

--- a/Bridge/BridgeDevice.h
+++ b/Bridge/BridgeDevice.h
@@ -1,15 +1,32 @@
 #pragma once
 
 #include "Bridge/IAdapter.h"
-#include <alljoyn/Status.h>
+#include <alljoyn/BusAttachment.h>
 
 namespace bridge
 {
   class BridgeDevice
   {
   public:
+    BridgeDevice(const shared_ptr<IAdapterDevice>&, const shared_ptr<IAdapter>&);
+    virtual ~BridgeDevice();
+
     QStatus Shutdown();
-    QStatus Initialize(shared_ptr<IAdapterDevice> const& dev);
+    QStatus Initialize();
+
+    ajn::BusAttachment& GetBusAttachment()
+    {
+      return m_busAttachment;
+    }
+
+    shared_ptr<IAdapterDevice> GetAdapterDevice()
+    {
+      return m_parent;
+    }
+
+  private:
+    shared_ptr<IAdapterDevice> m_parent;
+    ajn::BusAttachment m_busAttachment;
   };
 }
 

--- a/Bridge/ConfigManager.cpp
+++ b/Bridge/ConfigManager.cpp
@@ -124,6 +124,7 @@ ConfigManager::ConnectToAllJoyn()
 QStatus
 ConfigManager::BuildServiceName()
 {
+  DSBLOG_NOT_IMPLEMENTED();
   return ER_NOT_IMPLEMENTED;
 }
 

--- a/Bridge/ConfigManager.cpp
+++ b/Bridge/ConfigManager.cpp
@@ -1,5 +1,7 @@
-#include "Bridge/ConfigManager.h"
-#include "Bridge/IAdapter.h"
+#include "ConfigManager.h"
+
+#include "AllJoynHelper.h"
+#include "IAdapter.h"
 #include "Common/Log.h"
 
 using namespace bridge;
@@ -124,8 +126,24 @@ ConfigManager::ConnectToAllJoyn()
 QStatus
 ConfigManager::BuildServiceName()
 {
-  DSBLOG_NOT_IMPLEMENTED();
-  return ER_NOT_IMPLEMENTED;
+  m_serviceName.clear();
+
+  std::string tmp = AllJoynHelper::EncodeStringForRootServiceName(m_adapter.GetExposedAdapterPrefix());
+  if (tmp.empty()) {
+    return ER_BUS_BAD_BUS_NAME;
+  }
+
+  m_serviceName = tmp + ".DeviceSystemBridge";
+
+  tmp = AllJoynHelper::EncodeStringForServiceName(m_adapter.GetAdapterName());
+  if (tmp.empty()) {
+    m_serviceName.empty();
+    return ER_BUS_BAD_BUS_NAME;
+  }
+
+  m_serviceName += ".";
+  m_serviceName += tmp;
+  return ER_OK;
 }
 
 bool

--- a/Bridge/ConfigManager.cpp
+++ b/Bridge/ConfigManager.cpp
@@ -92,14 +92,14 @@ ConfigManager::ConnectToAllJoyn()
   st = m_busAttachment->Connect();
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to connect to AllJoyn bus: %d", st);
+    DSBLOG_WARN("Failed to connect to AllJoyn bus: %s", QCC_StatusText(st));
     return st;
   }
 
   st = m_busAttachment->RequestName(m_serviceName.c_str(), DBUS_NAME_FLAG_REPLACE_EXISTING | DBUS_NAME_FLAG_DO_NOT_QUEUE);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to get name %s on AllJoyn bus: %d", m_serviceName.c_str(), st);
+    DSBLOG_WARN("Failed to get name %s on AllJoyn bus: %s", m_serviceName.c_str(), QCC_StatusText(st));
     return st;
   }
 
@@ -107,14 +107,14 @@ ConfigManager::ConnectToAllJoyn()
   st = m_busAttachment->BindSessionPort(m_sessionPort, sessionOpts, *this);
   if (!st)
   {
-    DSBLOG_WARN("Failed to bind session port: %d", st);
+    DSBLOG_WARN("Failed to bind session port: %s", QCC_StatusText(st));
     return st;
   }
 
   st = m_busAttachment->AdvertiseName(m_serviceName.c_str(), sessionOpts.transports);
   if (!st)
   {
-    DSBLOG_WARN("Failed to advertise service name: %d", st);
+    DSBLOG_WARN("Failed to advertise service name: %s", QCC_StatusText(st));
     return st;
   }
 
@@ -159,7 +159,7 @@ ConfigManager::SessionJoined(ajn::SessionPort, ajn::SessionId id, const char*)
   QStatus st = m_busAttachment->SetSessionListener(id, this);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to set session listener: %d", st);
+    DSBLOG_WARN("Failed to set session listener: %s", QCC_StatusText(st));
     return;
   }
 
@@ -167,7 +167,7 @@ ConfigManager::SessionJoined(ajn::SessionPort, ajn::SessionId id, const char*)
   st = m_busAttachment->SetLinkTimeout(id, timeout);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to set session link timeout to %" PRIu32 ": %d", timeout, st);
+    DSBLOG_WARN("Failed to set session link timeout to %" PRIu32 ": %s", timeout, QCC_StatusText(st));
     return;
   }
 }

--- a/Bridge/ConfigManager.cpp
+++ b/Bridge/ConfigManager.cpp
@@ -105,14 +105,14 @@ ConfigManager::ConnectToAllJoyn()
 
   ajn::SessionOpts sessionOpts(ajn::SessionOpts::TRAFFIC_MESSAGES, true, ajn::SessionOpts::PROXIMITY_ANY, ajn::TRANSPORT_ANY);
   st = m_busAttachment->BindSessionPort(m_sessionPort, sessionOpts, *this);
-  if (!st)
+  if (st != ER_OK)
   {
     DSBLOG_WARN("Failed to bind session port: %s", QCC_StatusText(st));
     return st;
   }
 
   st = m_busAttachment->AdvertiseName(m_serviceName.c_str(), sessionOpts.transports);
-  if (!st)
+  if (st != ER_OK)
   {
     DSBLOG_WARN("Failed to advertise service name: %s", QCC_StatusText(st));
     return st;

--- a/Bridge/DeviceMain.cpp
+++ b/Bridge/DeviceMain.cpp
@@ -95,6 +95,7 @@ QStatus
 bridge::DeviceMain::CreateMethodsAndSignals()
 {
   // TODO
+  DSBLOG_NOT_IMPLEMENTED();
   return ER_NOT_IMPLEMENTED;
 }
 

--- a/Bridge/DeviceMain.cpp
+++ b/Bridge/DeviceMain.cpp
@@ -46,7 +46,7 @@ bridge::DeviceMain::Initialize()
   st = AddInterface(*m_interfaceDescription);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to add interface to bus object: %d", st);
+    DSBLOG_WARN("Failed to add interface to bus object: %s", QCC_StatusText(st));
     return st;
   }
 
@@ -62,7 +62,7 @@ bridge::DeviceMain::Initialize()
     st = AddMethodHandler(member, static_cast<ajn::MessageReceiver::MethodHandler>(&DeviceMain::AJMethod));
     if (st != ER_OK)
     {
-      DSBLOG_WARN("Failed to add method handler: %d", st);
+      DSBLOG_WARN("Failed to add method handler: %s", QCC_StatusText(st));
       return st;
     }
   }
@@ -70,7 +70,7 @@ bridge::DeviceMain::Initialize()
   st = m_parent.GetBusAttachment().RegisterBusObject(*this);
   if (st != ER_OK)
   {
-    DSBLOG_WARN("Failed to register bus object: %d", st);
+    DSBLOG_WARN("Failed to register bus object: %s", QCC_StatusText(st));
     return st;
   }
 

--- a/Bridge/DeviceMain.cpp
+++ b/Bridge/DeviceMain.cpp
@@ -1,7 +1,24 @@
 #include "DeviceMain.h"
 
-bridge::DeviceMain::DeviceMain()
-  : m_indexForSignal(1)
+#include "AllJoynHelper.h"
+#include "Common/Log.h"
+
+namespace
+{
+  DSB_DECLARE_LOGNAME(DeviceMain);
+}
+
+static std::string BuildBusObjectPath(const std::string& name)
+{
+  std::string encodedName;
+  bridge::AllJoynHelper::EncodeBusObjectName(name, encodedName);
+  return "/" + encodedName;
+}
+
+bridge::DeviceMain::DeviceMain(BridgeDevice& parent)
+  : ajn::BusObject(BuildBusObjectPath(m_parent.GetAdapterDevice()->GetName()).c_str(), false)
+  , m_parent(parent)
+  , m_indexForSignal(1)
   , m_indexForMethod(1)
   , m_registeredOnAllJoyn(false)
 {
@@ -18,9 +35,46 @@ bridge::DeviceMain::Shutdown()
 }
 
 QStatus
-bridge::DeviceMain::Initialize(shared_ptr<BridgeDevice> const&)
+bridge::DeviceMain::Initialize()
 {
   QStatus st = ER_OK;
+
+  st = CreateMethodsAndSignals();
+  if (st != ER_OK)
+    return st;
+
+  st = AddInterface(*m_interfaceDescription);
+  if (st != ER_OK)
+  {
+    DSBLOG_WARN("Failed to add interface to bus object: %d", st);
+    return st;
+  }
+
+  for (std::map<std::string, DeviceMethod*>::iterator i = m_deviceMethods.begin(); i != m_deviceMethods.end(); ++i)
+  {
+    const char* methodName = i->first.c_str();
+    const ajn::InterfaceDescription::Member* member = m_interfaceDescription->GetMember(methodName);
+    if (!member) {
+      DSBLOG_WARN("Failed to find InterfaceDescriptionMember for %s", methodName);
+      return ER_INVALID_DATA;
+    }
+
+    st = AddMethodHandler(member, static_cast<ajn::MessageReceiver::MethodHandler>(&DeviceMain::AJMethod));
+    if (st != ER_OK)
+    {
+      DSBLOG_WARN("Failed to add method handler: %d", st);
+      return st;
+    }
+  }
+
+  st = m_parent.GetBusAttachment().RegisterBusObject(*this);
+  if (st != ER_OK)
+  {
+    DSBLOG_WARN("Failed to register bus object: %d", st);
+    return st;
+  }
+
+  m_registeredOnAllJoyn = true;
   return st;
 }
 
@@ -37,3 +91,14 @@ bridge::DeviceMain::IsSignalNameUnique(std::string const&)
   return false;
 }
 
+QStatus
+bridge::DeviceMain::CreateMethodsAndSignals()
+{
+  // TODO
+  return ER_NOT_IMPLEMENTED;
+}
+
+void
+bridge::DeviceMain::AJMethod(const ajn::InterfaceDescription::Member*, ajn::Message&)
+{
+}

--- a/Bridge/DeviceMain.h
+++ b/Bridge/DeviceMain.h
@@ -12,19 +12,16 @@ namespace bridge
   class DeviceMethod;
   class DeviceSignal;
 
-  class DeviceMain
+  class DeviceMain : private ajn::BusObject
   {
-    DeviceMain();
+    DeviceMain(BridgeDevice& parent);
     virtual ~DeviceMain();
 
-    QStatus Initialize(shared_ptr<BridgeDevice> const& parent);
+    QStatus Initialize();
 
     bool IsMethodNameUnique(std::string const& name);
     bool IsSignalNameUnique(std::string const& name);
     void HandleSignal(IAdapterSignal const& adapterSignal);
-
-    inline shared_ptr<ajn::BusObject> GetBusObject() const
-      { return m_busObject; }
 
     inline int GetIndexForMethod()
       { return m_indexForMethod++; }
@@ -34,15 +31,15 @@ namespace bridge
 
   private:
     void Shutdown();
+    QStatus CreateMethodsAndSignals();
+    void AJMethod(const ajn::InterfaceDescription::Member*, ajn::Message&);
 
   private:
+    BridgeDevice&                               m_parent;
     int                                         m_indexForSignal;
     int                                         m_indexForMethod;
-    shared_ptr<ajn::BusObject>                  m_busObject;
-    std::unique_ptr<ajn::InterfaceDescription>  m_interfaceDescrtipion;
-    std::string                                 m_busObjectPath;
+    std::unique_ptr<ajn::InterfaceDescription>  m_interfaceDescription;
     std::string                                 m_interfaceName;
-    std::shared_ptr<BridgeDevice>               m_parent;
     std::map<std::string, DeviceMethod* >       m_deviceMethods;
     std::map<std::string, DeviceSignal* >       m_deviceSignals;
     bool                                        m_registeredOnAllJoyn;

--- a/Bridge/DeviceMethod.cpp
+++ b/Bridge/DeviceMethod.cpp
@@ -1,5 +1,12 @@
 #include "DeviceMethod.h"
 
+#include "Common/Log.h"
+
+namespace
+{
+  DSB_DECLARE_LOGNAME(DeviceMethod);
+}
+
 bridge::DeviceMethod::DeviceMethod(DeviceMain& dev)
   : m_parent(dev)
 {
@@ -18,18 +25,21 @@ bridge::DeviceMethod::InvokeMethod(ajn::Message const&, ajn::MsgArg*, size_t)
 QStatus
 bridge::DeviceMethod::Initialize(shared_ptr<IAdapterMethod> const&)
 {
+  DSBLOG_NOT_IMPLEMENTED();
   return ER_NOT_IMPLEMENTED;
 }
 
 QStatus
 bridge::DeviceMethod::SetName(std::string const&)
 {
+  DSBLOG_NOT_IMPLEMENTED();
   return ER_NOT_IMPLEMENTED;
 }
 
 QStatus
 bridge::DeviceMethod::BuildSignature(AdapterValueVector const&, std::string&, std::string&)
 {
+  DSBLOG_NOT_IMPLEMENTED();
   return ER_NOT_IMPLEMENTED;
 }
 

--- a/Bridge/DeviceMethod.cpp
+++ b/Bridge/DeviceMethod.cpp
@@ -1,6 +1,7 @@
 #include "DeviceMethod.h"
 
-bridge::DeviceMethod::DeviceMethod()
+bridge::DeviceMethod::DeviceMethod(DeviceMain& dev)
+  : m_parent(dev)
 {
 }
 
@@ -15,7 +16,7 @@ bridge::DeviceMethod::InvokeMethod(ajn::Message const&, ajn::MsgArg*, size_t)
 }
 
 QStatus
-bridge::DeviceMethod::Initialize(shared_ptr<DeviceMain> const&, shared_ptr<IAdapterMethod> const&)
+bridge::DeviceMethod::Initialize(shared_ptr<IAdapterMethod> const&)
 {
   return ER_NOT_IMPLEMENTED;
 }

--- a/Bridge/DeviceMethod.h
+++ b/Bridge/DeviceMethod.h
@@ -14,10 +14,10 @@ namespace bridge
   class DeviceMethod
   {
   public:
-    DeviceMethod();
+    DeviceMethod(DeviceMain&);
     virtual ~DeviceMethod();
 
-    QStatus Initialize(shared_ptr<DeviceMain> const& parent, shared_ptr<IAdapterMethod> const& adapterMethod);
+    QStatus Initialize(shared_ptr<IAdapterMethod> const& adapterMethod);
     uint32_t InvokeMethod(ajn::Message const& msg, ajn::MsgArg* outArgs, size_t numOutArgs);
 
     inline std::string const& GetName() const
@@ -28,11 +28,11 @@ namespace bridge
     QStatus BuildSignature(AdapterValueVector const& valueList, std::string& sig, std::string& parameterNames);
 
   private:
+    DeviceMain&             m_parent;
     std::string             m_exposedName;
     std::string             m_inSignature;
     std::string             m_outSignature;
     std::string             m_parameterNames;
-    shared_ptr<DeviceMain>  m_parent;
   };
 }
 

--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -88,7 +88,7 @@ common::Logger::IsLevelEnabled(char const* module, Level level)
 }
 
 void
-common::Logger::VaLog(const char* module, Level level, const char* /*file*/, int /*line*/,
+common::Logger::VaLog(const char* module, Level level, const char* file, int line,
   const char* format, va_list args)
 {
   struct tm result;
@@ -99,7 +99,7 @@ common::Logger::VaLog(const char* module, Level level, const char* /*file*/, int
   size_t n = strftime(buff, sizeof(buff) - 1, "%Y-%m-%dT%T", &result);
   if (n > 0)
     buff[n] = '\0';
-  fprintf(gLog, "%s (%5s) Thread-" ThreadId_FMT " [%s] - ", buff, LevelToString(level), GetCurrentThreadId(), module);
+  fprintf(gLog, "%s (%5s) Thread-" ThreadId_FMT " [%s:%s:%d] - ", buff, LevelToString(level), GetCurrentThreadId(), module, file, line);
   vfprintf(gLog, format, args);
   fprintf(gLog, "\n");
 }

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -52,3 +52,5 @@ namespace common
 #define DSBLOG_WARN(FORMAT, ...) DSBLOG(DSB_LOGLEVEL_WARN, __dsb_logger_module_name__, FORMAT, ##__VA_ARGS__)
 #define DSBLOG_ERROR(FORMAT, ...) DSBLOG(DSB_LOGLEVEL_ERROR, __dsb_logger_module_name__, FORMAT, ##__VA_ARGS__)
 
+#define DSBLOG_NOT_IMPLEMENTED() DSBLOG_WARN("%s has not been implemented", __func__);
+

--- a/main.cpp
+++ b/main.cpp
@@ -52,7 +52,7 @@ int main(int /*argc*/, char* /*argv*/ [])
   st = bridge->Initialize();
   if (st != ER_OK)
   {
-    DSBLOG_ERROR("failed to initialize bridge: 0x%x", st);
+    DSBLOG_ERROR("failed to initialize bridge: %s", QCC_StatusText(st));
     return 1;
   }
 


### PR DESCRIPTION
With this, we get devices exposed on the AllJoyn bus. I tested using [the example sessions application](https://allseenalliance.org/framework/documentation/develop/run-sample-apps/test/sessions).

To test yourself, run `alljoyn-daemon` in one terminal, `sessions` (from `alljoyn/build/linux/x86_64/release/dist/cpp/bin` or similar), then `moc-adapter` in a third terminal. The `sessions` terminal should show output like:

```
NameOwnerChanged: name=:W_uTxW3i.7, oldOwner=<none>, newOwner=:W_uTxW3i.7
NameOwnerChanged: name=com.Acme.DeviceSystemBridge.DSBMockAdapter, oldOwner=<none>, newOwner=:W_uTxW3i.7
FoundAdvertisedName name=com.Acme.DeviceSystemBridge.DSBMockAdapter namePrefix=com
FoundAdvertisedName name=com.Acme.DeviceSystemBridge.DSBMockAdapter namePrefix=com.
```

I also changed the logging a little bit to make it easier to figure out where we call an unimplemented function, and to make it easier to track down errors.
