### PR TITLE
CircleCI dependency order

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,9 +18,9 @@ dependencies:
         cd ~ ;
         wget --no-check-certificate https://allseenalliance.org/releases/alljoyn/15.09/alljoyn-15.09.00a-src.tar.gz ;
         tar -xf alljoyn-15.09.00a-src.tar.gz ;
-        cd alljoyn-15.09.00a-src ;
-        scons BINDINGS=cpp OS=linux CPU=x86_64 VARIANT=release BUILD_SERVICE_SAMPLES=off WS=off BT=off ICE=off -j4 ;
-      fi
+      fi ;
+      cd ~/alljoyn-15.09.00a-src ;
+      scons BINDINGS=cpp OS=linux CPU=x86_64 VARIANT=release BUILD_SERVICE_SAMPLES=off WS=off BT=off ICE=off -j4
 
   post:
     - make -j4

--- a/circle.yml
+++ b/circle.yml
@@ -7,19 +7,19 @@ dependencies:
   pre:
     - sudo apt-get update
     - sudo apt-get install libcap-dev scons libgtest-dev
-    - if [[ ! -e ~/alljoyn-15.09.00a-src ]] ; then
-        cd ~ ;
-        wget --no-check-certificate https://allseenalliance.org/releases/alljoyn/15.09/alljoyn-15.09.00a-src.tar.gz ;
-        tar -xf alljoyn-15.09.00a-src.tar.gz ;
-        cd alljoyn-15.09.00a-src ;
-        scons BINDINGS=cpp OS=linux CPU=x86_64 VARIANT=release BUILD_SERVICE_SAMPLES=off WS=off BT=off ICE=off -j4 ;
-      fi
     - if [[ ! -e ~/gtest ]] ; then
         cd ~ ;
         cp -r /usr/src/gtest . ;
         cd gtest ;
         cmake -DCMAKE_BUILD_TYPE=RELEASE . ;
         make ;
+      fi
+    - if [[ ! -e ~/alljoyn-15.09.00a-src ]] ; then
+        cd ~ ;
+        wget --no-check-certificate https://allseenalliance.org/releases/alljoyn/15.09/alljoyn-15.09.00a-src.tar.gz ;
+        tar -xf alljoyn-15.09.00a-src.tar.gz ;
+        cd alljoyn-15.09.00a-src ;
+        scons BINDINGS=cpp OS=linux CPU=x86_64 VARIANT=release BUILD_SERVICE_SAMPLES=off WS=off BT=off ICE=off -j4 ;
       fi
 
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,16 @@
 machine:
   environment:
-    ALLJOYN_INSTALL_DIR: \$(HOME)/alljoyn-15.09.00a-src/build/linux/x86_64/release/dist/cpp
-    GTEST_DIR: \$(HOME)/gtest
+    ALLJOYN_INSTALL_DIR: /home/ubuntu/alljoyn-15.09.00a-src/build/linux/x86_64/release/dist/cpp
+    GTEST_DIR: /home/ubuntu/gtest
 
 dependencies:
   pre:
     - sudo apt-get update
     - sudo apt-get install libcap-dev scons libgtest-dev
-    - if [[ ! -e ~/gtest ]] ; then
-        cd ~ ;
-        cp -r /usr/src/gtest . ;
-        cd gtest ;
+    - if [[ ! -e "$GTEST_DIR" ]] ; then
+        cd "$GTEST_DIR/.." ;
+        cp -r /usr/src/gtest "$GTEST_DIR" ;
+        cd "$GTEST_DIR" ;
         cmake -DCMAKE_BUILD_TYPE=RELEASE . ;
         make ;
       fi
@@ -20,6 +20,7 @@ dependencies:
         tar -xf alljoyn-15.09.00a-src.tar.gz ;
       fi ;
       cd ~/alljoyn-15.09.00a-src ;
+      unset GTEST_DIR ;
       scons BINDINGS=cpp OS=linux CPU=x86_64 VARIANT=release BUILD_SERVICE_SAMPLES=off WS=off BT=off ICE=off -j4
 
   post:


### PR DESCRIPTION
I made a mistake when I added the GTest build, and it didn't show up on my CircleCI because it was cached. [This fixes it](https://circleci.com/gh/brendanlong/portabledsb/51), and makes future problems easier to notice.
