### PR TITLE
Remove gotos and just use multiple returns.

### DIFF
--- a/Bridge/BridgeDevice.cpp
+++ b/Bridge/BridgeDevice.cpp
@@ -46,17 +46,17 @@ bridge::BridgeDevice::Initialize()
   // create Device service name
   st = BuildServiceName();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // init alljoyn
   st = InitializeAllJoyn();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // initialize about service
   st = m_about.Initialize(m_busAttachment);
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // set device info in about
   m_about.SetApplicationName(m_adapter->GetExposedApplicationName().c_str());
@@ -76,22 +76,22 @@ bridge::BridgeDevice::Initialize()
   // create device properties
   st = CreateDeviceProperties();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // create main device
   st = m_deviceMain.Initialize();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // Create a control panel if requested by the caller.
   st = InitControlPanel();
   if (st != ER_OK)
-    goto leave;
+    return st;
   
   // Create Lighting Service if requested
   st = InitLightingService();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   interface = m_deviceMain.GetInterfaceDescription();
   if (!interface)
@@ -104,20 +104,15 @@ bridge::BridgeDevice::Initialize()
   // connect to AllJoyn
   st = ConnectToAllJoyn();
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // register signals
   st = RegisterSignalHandlers(true);
   if (st != ER_OK)
-    goto leave;
+    return st;
 
   // announce
-  m_about.Announce();
-
-leave:
-  if (st != ER_OK)
-    Shutdown();
-  return st;
+  return m_about.Announce();
 }
 
 QStatus

--- a/Bridge/DeviceMethod.h
+++ b/Bridge/DeviceMethod.h
@@ -19,7 +19,7 @@ namespace bridge
 
     // TODO: error code?
     // TODO: should that first arg be constant?
-    uint32_t InvokeMethod(ajn::Message& msg, ajn::MsgArg* outArgs, size_t* numOutArgs);
+    uint32_t InvokeMethod(ajn::Message& msg, std::vector<ajn::MsgArg>& outArgs);
 
     inline std::string const& GetName() const
       { return m_exposedName; }

--- a/DeviceProviders/AllJoynProvider.cpp
+++ b/DeviceProviders/AllJoynProvider.cpp
@@ -54,10 +54,10 @@ AllJoynStatus AllJoynProvider::Start()
 {
   QStatus status = ER_OK;
 
-  #define AJ_CHECK(ST) { status = ST; if (status != ER_OK) goto leave; }
+  #define AJ_CHECK(ST) { status = ST; if (status != ER_OK) return AllJoynStatus(status); }
 
   if (m_bus != NULL)
-    goto leave;
+    return AllJoynStatus(ER_FAIL);
 
   if (!m_alljoynInitialized)
   {
@@ -78,10 +78,6 @@ AllJoynStatus AllJoynProvider::Start()
   AJ_CHECK( m_bus->WhoImplements(NULL) );
 
   m_isListening = true;
-
-  leave:
-    if (status != ER_OK)
-      Shutdown();
 
   return AllJoynStatus(status);
 }


### PR DESCRIPTION
This is mostly straightforward. The only complicated one is DeviceMethod::InvokeMethod, where using std::vector& as the return type made it significantly simpler.
